### PR TITLE
Fix panic parsing legacy try/catch with a multi-value handler signature

### DIFF
--- a/crates/tests/tests/legacy-exceptions-multivalue-catch.rs
+++ b/crates/tests/tests/legacy-exceptions-multivalue-catch.rs
@@ -1,0 +1,98 @@
+//! Regression test: parsing a legacy `try` whose `catch` / `catch_all`
+//! handler has a multi-value signature.
+//!
+//! A legacy-exceptions handler block's signature is implicit in the
+//! encoding (`catch <tag>` carries no blocktype). Its synthesized type
+//! is `[tag params] -> [try results]`; when that pair is multi-value
+//! and was never declared as a `func` type, the IR builder used to
+//! panic in `local_function::context::impl_push_control`
+//! ("attempted to push a control frame for an instruction sequence
+//! with a type that does not exist"). `parse_local_functions` now
+//! pre-registers these types, mirroring `add_entry_ty`.
+
+use walrus::Module;
+
+fn parse(wat: &str) -> Module {
+    let wasm = wat::parse_str(wat).expect("wat should assemble");
+    Module::from_buffer(&wasm).expect("walrus should parse the module")
+}
+
+/// Round-trip: parse, emit, re-parse. Ensures the synthesized handler
+/// type does not break emission.
+fn round_trip(wat: &str) {
+    let mut module = parse(wat);
+    let emitted = module.emit_wasm();
+    Module::from_buffer(&emitted).expect("emitted module should re-parse");
+}
+
+/// Minimal case — `[i32] -> [i32]` handler, no GC. Tag param `i32`,
+/// `try (result i32)`, so the handler signature is `[i32] -> [i32]`,
+/// which the module never declares as a `func` type.
+#[test]
+fn try_catch_multivalue_handler_i32() {
+    round_trip(
+        r#"(module
+          (tag $e (param i32))
+          (func $f (result i32)
+            try (result i32)
+              i32.const 0
+            catch $e
+            end))"#,
+    );
+}
+
+/// `catch_all` handler — signature `[] -> [try results]`. The `try`
+/// here takes a param, so its own blocktype is `[i32] -> [i32 i32]`;
+/// the `catch_all` handler is `[] -> [i32 i32]`, which is neither the
+/// `try` blocktype nor the function type (`[] -> [i32]`) — so the
+/// handler type genuinely has no pre-existing match and exercises the
+/// `CatchAll` arm of the fix.
+#[test]
+fn try_catch_all_multivalue_handler() {
+    round_trip(
+        r#"(module
+          (func $f (result i32)
+            i32.const 7
+            try (param i32) (result i32 i32)
+              i32.const 9
+            catch_all
+              unreachable
+            end
+            drop))"#,
+    );
+}
+
+/// GC reference types in the handler signature — `[ref null $s] ->
+/// [ref null $s]`. This is the shape the bug was originally reported
+/// against (a Kotlin/Wasm module); the GC types are incidental, the
+/// `i32` case above is the true minimal repro.
+#[test]
+fn try_catch_multivalue_handler_gc_ref() {
+    round_trip(
+        r#"(module
+          (type $s (struct (field i32)))
+          (tag $e (param (ref null $s)))
+          (func $f (result (ref null $s))
+            try (result (ref null $s))
+              ref.null $s
+            catch $e
+            end))"#,
+    );
+}
+
+/// Two `catch` clauses on one `try` — both handlers share the same
+/// `try` result types, exercising the frame-stays-on-stack path.
+#[test]
+fn try_multiple_catch_multivalue_handlers() {
+    round_trip(
+        r#"(module
+          (tag $a (param i32))
+          (tag $b (param i32))
+          (func $f (result i32)
+            try (result i32)
+              i32.const 0
+            catch $a
+            catch $b
+            end))"#,
+    );
+}

--- a/src/module/functions/mod.rs
+++ b/src/module/functions/mod.rs
@@ -379,6 +379,9 @@ impl Module {
             let results = type_.results().to_vec();
             self.types.add_entry_ty(&results);
 
+            // Likewise for legacy `catch` handler block types.
+            self.register_legacy_catch_block_types(&body, indices)?;
+
             // Next up comes all the locals of the function.
             let mut locals_reader = body.get_locals_reader()?;
             for _ in 0..locals_reader.get_count() {
@@ -426,6 +429,65 @@ impl Module {
             self.funcs.arena[id].kind = FunctionKind::Local(func);
         }
 
+        Ok(())
+    }
+
+    /// Pre-register the implicit `[tag params] -> [try results]` `Type` of
+    /// every non-`Simple` legacy `catch` / `catch_all` handler in `body`.
+    ///
+    /// Legacy `catch` handler signatures are implicit in the encoding and
+    /// so never in `ModuleTypes`. The IR builder runs in parallel over
+    /// `&Module` and cannot register them itself, so — like `add_entry_ty`
+    /// for the function entry block — they're pre-registered here.
+    fn register_legacy_catch_block_types(
+        &mut self,
+        body: &wasmparser::FunctionBody,
+        indices: &IndicesToIds,
+    ) -> Result<()> {
+        use wasmparser::{BlockType, Operator};
+
+        // One entry per open structured frame; `Some` holds a `try`'s
+        // result types. A `catch` pairs with the innermost `try`, i.e.
+        // the top frame.
+        let mut frames: Vec<Option<Vec<ValType>>> = Vec::new();
+        for op in body.get_operators_reader()? {
+            match op? {
+                Operator::Block { .. }
+                | Operator::Loop { .. }
+                | Operator::If { .. }
+                | Operator::TryTable { .. } => frames.push(None),
+                Operator::Try { blockty } => frames.push(Some(match blockty {
+                    BlockType::Empty => Vec::new(),
+                    BlockType::Type(t) => ValType::from_wasmparser_type(t, indices)?.into_vec(),
+                    BlockType::FuncType(i) => self.types.results(indices.get_type(i)?).to_vec(),
+                })),
+                // `end` closes any frame; `delegate` closes a `try` frame.
+                Operator::End | Operator::Delegate { .. } => {
+                    frames.pop();
+                }
+                Operator::Catch { tag_index } => {
+                    if let Some(Some(results)) = frames.last() {
+                        let results = results.clone();
+                        let tag_ty = self.tags.get(indices.get_tag(tag_index)?).ty();
+                        let params = self.types.params(tag_ty).to_vec();
+                        // `Simple` handlers (0 params, <=1 result) need no `Type`.
+                        if !matches!((params.len(), results.len()), (0, 0) | (0, 1)) {
+                            self.types.add(&params, &results);
+                        }
+                    }
+                }
+                Operator::CatchAll => {
+                    if let Some(Some(results)) = frames.last() {
+                        // Handler is `[] -> results`; multi-value iff >1 result.
+                        if results.len() > 1 {
+                            let results = results.clone();
+                            self.types.add(&[], &results);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

A legacy-exceptions `catch` / `catch_all` handler block has a signature implicit in the encoding — a bare `catch <tag>` carries no blocktype — equal to `[tag params] -> [try results]`. That `Type` is never present in `ModuleTypes`, so the IR builder's `InstrSeqType::existing` lookup returns `None` and the `.unwrap()` in `local_function/mod.rs` panics:

```
attempted to push a control frame for an instruction sequence with a type that does not exist
```

Reported in #315.

## Reproducer (panics before this change, no GC needed)

```wat
(module
  (tag $e (param i32))
  (func $f (result i32)
    try (result i32) i32.const 0 catch $e end))
```

## Fix — why a pre-pass rather than `InstrSeqType::new` at the catch arm

#315's own "Suggested fix" was to swap `InstrSeqType::existing → InstrSeqType::new` in the `Catch` / `CatchAll` arms. That's structurally blocked here:

- `ValidationContext { module: &'a Module, .. }` — the IR builder holds `&Module`, by-design.
- `LocalFunction::parse` is invoked from a `maybe_parallel!` block, so `&Module` is shared across threads.
- `InstrSeqType::new` requires `&mut ModuleTypes`.

Swapping `existing → new` at the catch arms would force either giving up parallel parsing or restructuring the borrow shape across the IR builder — a much larger change than the bug warrants.

The pre-pass keeps all type-arena mutation in the existing serial setup loop in `parse_local_functions`, alongside `add_entry_ty` — which already solves the same shape of problem for the function entry block (its type is also implicit in the encoding). New helper `register_legacy_catch_block_types` walks the function body once, tracks the `try` frame stack, and pre-registers each non-`Simple` handler signature. `Simple` (0 params, ≤1 result) handlers are skipped; `types.add` dedups, so re-registering a declared type is a no-op.

## Tests

`crates/tests/tests/legacy-exceptions-multivalue-catch.rs` — 4 parse + round-trip cases (`i32`, GC ref, multi-`catch`, `catch_all` with try-with-params). All four panic on `main`; all four pass with this change. Full `cargo test --all` is green.

Fixes #315.

---

*Drafted with AI assistance (Claude Code). The fix was developed against the walrus source; the regression tests were confirmed to fail without it and pass with it, and `cargo test --all` was run green, during that AI-assisted preparation.*